### PR TITLE
API de usuarios con certificaciones y pruebas BDD

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,51 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Optional
+
+app = FastAPI()
+
+class UsuarioBase(BaseModel):
+    nombre: str
+    correo: str
+
+class Usuario(UsuarioBase):
+    id: int
+    certificaciones: List[str] = []
+
+class UsuarioActualizacion(BaseModel):
+    nombre: Optional[str] = None
+    correo: Optional[str] = None
+
+class Certificacion(BaseModel):
+    nombre: str
+
+usuarios = {}
+contador_id = 1
+
+@app.post("/usuarios", response_model=Usuario)
+def crear_usuario(usuario: UsuarioBase):
+    global contador_id
+    nuevo = Usuario(id=contador_id, nombre=usuario.nombre, correo=usuario.correo, certificaciones=[])
+    usuarios[contador_id] = nuevo
+    contador_id += 1
+    return nuevo
+
+@app.put("/usuarios/{usuario_id}", response_model=Usuario)
+def actualizar_usuario(usuario_id: int, datos: UsuarioActualizacion):
+    if usuario_id not in usuarios:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+    usuario = usuarios[usuario_id]
+    if datos.nombre is not None:
+        usuario.nombre = datos.nombre
+    if datos.correo is not None:
+        usuario.correo = datos.correo
+    usuarios[usuario_id] = usuario
+    return usuario
+
+@app.post("/usuarios/{usuario_id}/certificaciones", response_model=Usuario)
+def agregar_certificacion(usuario_id: int, cert: Certificacion):
+    if usuario_id not in usuarios:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+    usuario = usuarios[usuario_id]
+    usuario.certificaciones.append(cert.nombre)
+    return usuario

--- a/features/steps/usuarios.steps.js
+++ b/features/steps/usuarios.steps.js
@@ -1,0 +1,50 @@
+const { Given, When, Then, BeforeAll, AfterAll } = require('@cucumber/cucumber');
+const axios = require('axios');
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+let servidor;
+
+BeforeAll(function() {
+  servidor = spawn('uvicorn', ['app.main:app', '--port', '8000']);
+  return new Promise(resolve => setTimeout(resolve, 1000));
+});
+
+AfterAll(function() {
+  servidor.kill();
+});
+
+When('creo un usuario con nombre {string} y correo {string}', async function (nombre, correo) {
+  this.respuesta = await axios.post('http://localhost:8000/usuarios', { nombre, correo });
+  this.usuarioId = this.respuesta.data.id;
+});
+
+Given('que existe un usuario con nombre {string} y correo {string}', async function (nombre, correo) {
+  const res = await axios.post('http://localhost:8000/usuarios', { nombre, correo });
+  this.usuarioId = res.data.id;
+  this.respuesta = res;
+});
+
+When('actualizo el usuario a nombre {string}', async function (nuevoNombre) {
+  this.respuesta = await axios.put(`http://localhost:8000/usuarios/${this.usuarioId}`, { nombre: nuevoNombre });
+});
+
+When('agrego la certificación {string} al usuario', async function (certificacion) {
+  this.respuesta = await axios.post(`http://localhost:8000/usuarios/${this.usuarioId}/certificaciones`, { nombre: certificacion });
+});
+
+Then('el resultado es exitoso', function () {
+  assert.ok(this.respuesta.status >= 200 && this.respuesta.status < 300);
+});
+
+Then('el usuario creado tiene el nombre {string}', function (nombre) {
+  assert.strictEqual(this.respuesta.data.nombre, nombre);
+});
+
+Then('el usuario modificado tiene nombre {string}', function (nombre) {
+  assert.strictEqual(this.respuesta.data.nombre, nombre);
+});
+
+Then('el usuario tiene la certificación {string}', function (certificacion) {
+  assert.ok(this.respuesta.data.certificaciones.includes(certificacion));
+});

--- a/features/usuarios.feature
+++ b/features/usuarios.feature
@@ -1,0 +1,19 @@
+# language: es
+Característica: Gestión de usuarios
+
+  Escenario: Crear un usuario
+    Cuando creo un usuario con nombre "Juan" y correo "juan@example.com"
+    Entonces el resultado es exitoso
+    Y el usuario creado tiene el nombre "Juan"
+
+  Escenario: Modificar un usuario
+    Dado que existe un usuario con nombre "Ana" y correo "ana@example.com"
+    Cuando actualizo el usuario a nombre "Ana Maria"
+    Entonces el resultado es exitoso
+    Y el usuario modificado tiene nombre "Ana Maria"
+
+  Escenario: Agregar una certificación a un usuario
+    Dado que existe un usuario con nombre "Luis" y correo "luis@example.com"
+    Cuando agrego la certificación "Python Avanzado" al usuario
+    Entonces el resultado es exitoso
+    Y el usuario tiene la certificación "Python Avanzado"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "glue-code-bdd",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "cucumber-js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Resumen
- Implementa API de usuarios con FastAPI para crear, modificar y agregar certificaciones.
- Añade escenarios BDD en español con Gherkin para validar la creación, edición y certificaciones de usuarios.
- Configura entorno de pruebas con Cucumber y axios.

## Pruebas
- `pip install -r requirements.txt` (falló: Could not connect to proxy)
- `npm test` (falló: cucumber-js: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b7a47cb9e8832ebe31ff34e7afadb2