### PR TITLE
Agregar ejemplos avanzados de Gherkin con tablas, antecedentes y flujos negativos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Glue-code-BDD
+
+Proyecto de ejemplo para pruebas BDD con **Gherkin + Cucumber.js** contra una API en FastAPI.
+
+## Ejecutar pruebas
+
+```bash
+npm test
+```
+
+## Ejemplos incluidos
+
+- `features/usuarios.feature`: flujo básico de crear, actualizar y agregar certificaciones.
+- `features/usuarios_tablas.feature`: uso de **Antecedentes** y **Data Tables** para carga y validación de datos.
+- `features/usuarios_outline.feature`: uso de **Esquema del escenario** con múltiples ejemplos.
+- `features/usuarios_errores.feature`: flujos negativos con validación de errores HTTP.

--- a/features/steps/usuarios.steps.js
+++ b/features/steps/usuarios.steps.js
@@ -3,34 +3,53 @@ const axios = require('axios');
 const assert = require('assert');
 const { spawn } = require('child_process');
 
+const BASE_URL = 'http://127.0.0.1:8000';
 let servidor;
 
-BeforeAll(function() {
-  servidor = spawn('uvicorn', ['app.main:app', '--host', '0.0.0.0', '--port', '8000']);
-  return new Promise(resolve => setTimeout(resolve, 1000));
+async function esperarServidorListo(maxIntentos = 25, pausaMs = 200) {
+  for (let intento = 0; intento < maxIntentos; intento += 1) {
+    try {
+      await axios.get(`${BASE_URL}/openapi.json`);
+      return;
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, pausaMs));
+    }
+  }
+
+  throw new Error('No fue posible iniciar la API en http://127.0.0.1:8000');
+}
+
+BeforeAll(async function () {
+  servidor = spawn('uvicorn', ['app.main:app', '--host', '0.0.0.0', '--port', '8000'], {
+    stdio: 'ignore'
+  });
+
+  await esperarServidorListo();
 });
 
-AfterAll(function() {
-  servidor.kill();
+AfterAll(function () {
+  if (servidor) {
+    servidor.kill();
+  }
 });
 
 When('creo un usuario con nombre {string} y correo {string}', async function (nombre, correo) {
-  this.respuesta = await axios.post('http://127.0.0.1:8000/usuarios', { nombre, correo });
+  this.respuesta = await axios.post(`${BASE_URL}/usuarios`, { nombre, correo });
   this.usuarioId = this.respuesta.data.id;
 });
 
 Given('que existe un usuario con nombre {string} y correo {string}', async function (nombre, correo) {
-  const res = await axios.post('http://127.0.0.1:8000/usuarios', { nombre, correo });
+  const res = await axios.post(`${BASE_URL}/usuarios`, { nombre, correo });
   this.usuarioId = res.data.id;
   this.respuesta = res;
 });
 
 When('actualizo el usuario a nombre {string}', async function (nuevoNombre) {
-  this.respuesta = await axios.put(`http://127.0.0.1:8000/usuarios/${this.usuarioId}`, { nombre: nuevoNombre });
+  this.respuesta = await axios.put(`${BASE_URL}/usuarios/${this.usuarioId}`, { nombre: nuevoNombre });
 });
 
 When('agrego la certificación {string} al usuario', async function (certificacion) {
-  this.respuesta = await axios.post(`http://127.0.0.1:8000/usuarios/${this.usuarioId}/certificaciones`, { nombre: certificacion });
+  this.respuesta = await axios.post(`${BASE_URL}/usuarios/${this.usuarioId}/certificaciones`, { nombre: certificacion });
 });
 
 Then('el resultado es exitoso', function () {

--- a/features/steps/usuarios_avanzados.steps.js
+++ b/features/steps/usuarios_avanzados.steps.js
@@ -1,0 +1,108 @@
+const { Given, When, Then } = require('@cucumber/cucumber');
+const axios = require('axios');
+const assert = require('assert');
+
+const BASE_URL = 'http://127.0.0.1:8000';
+
+function tablaCampoValorAObjeto(dataTable) {
+  const filas = dataTable.hashes();
+  return filas.reduce((acc, fila) => {
+    acc[fila.campo] = fila.valor;
+    return acc;
+  }, {});
+}
+
+Given('que existen los siguientes usuarios base', async function (dataTable) {
+  const usuariosBase = dataTable.hashes();
+  this.usuariosPorNombre = this.usuariosPorNombre || {};
+
+  for (const usuario of usuariosBase) {
+    const respuesta = await axios.post(`${BASE_URL}/usuarios`, usuario);
+    this.usuariosPorNombre[respuesta.data.nombre] = respuesta.data;
+  }
+});
+
+Given('que selecciono al usuario {string}', function (nombre) {
+  assert.ok(this.usuariosPorNombre?.[nombre], `No se encontró el usuario base ${nombre}`);
+  this.usuarioSeleccionado = this.usuariosPorNombre[nombre];
+  this.usuarioId = this.usuarioSeleccionado.id;
+});
+
+Given('que no existe un usuario con id {int}', function (usuarioId) {
+  this.usuarioIdInexistente = usuarioId;
+});
+
+When('creo los siguientes usuarios', async function (dataTable) {
+  const usuarios = dataTable.hashes();
+  this.respuestasLote = [];
+
+  for (const usuario of usuarios) {
+    const respuesta = await axios.post(`${BASE_URL}/usuarios`, usuario);
+    this.respuestasLote.push(respuesta);
+  }
+});
+
+When('actualizo el usuario seleccionado con los datos', async function (dataTable) {
+  const payload = tablaCampoValorAObjeto(dataTable);
+  this.respuesta = await axios.put(`${BASE_URL}/usuarios/${this.usuarioId}`, payload);
+});
+
+When('intento agregar la certificación {string} al usuario con id {int}', async function (certificacion, usuarioId) {
+  try {
+    await axios.post(`${BASE_URL}/usuarios/${usuarioId}/certificaciones`, { nombre: certificacion });
+    assert.fail('Se esperaba error 404 y la operación fue exitosa');
+  } catch (error) {
+    if (!error.response) {
+      throw error;
+    }
+    this.errorHttp = error.response;
+  }
+});
+
+When('intento actualizar el usuario con id {int} con los datos', async function (usuarioId, dataTable) {
+  const payload = tablaCampoValorAObjeto(dataTable);
+
+  try {
+    await axios.put(`${BASE_URL}/usuarios/${usuarioId}`, payload);
+    assert.fail('Se esperaba error 404 y la operación fue exitosa');
+  } catch (error) {
+    if (!error.response) {
+      throw error;
+    }
+    this.errorHttp = error.response;
+  }
+});
+
+Then('todos los resultados son exitosos', function () {
+  assert.ok(Array.isArray(this.respuestasLote) && this.respuestasLote.length > 0);
+  this.respuestasLote.forEach((respuesta) => {
+    assert.ok(respuesta.status >= 200 && respuesta.status < 300);
+  });
+});
+
+Then('los usuarios creados incluyen', function (dataTable) {
+  const esperados = dataTable.hashes().map((fila) => fila.nombre);
+  const obtenidos = this.respuestasLote.map((respuesta) => respuesta.data.nombre);
+
+  esperados.forEach((nombreEsperado) => {
+    assert.ok(obtenidos.includes(nombreEsperado), `No se encontró ${nombreEsperado} en ${obtenidos}`);
+  });
+});
+
+Then('el usuario seleccionado tiene los datos', function (dataTable) {
+  const esperado = tablaCampoValorAObjeto(dataTable);
+
+  Object.entries(esperado).forEach(([campo, valor]) => {
+    assert.strictEqual(String(this.respuesta.data[campo]), valor);
+  });
+});
+
+Then('el servicio responde con código {int}', function (statusCode) {
+  assert.ok(this.errorHttp, 'No se capturó error HTTP');
+  assert.strictEqual(this.errorHttp.status, statusCode);
+});
+
+Then('el error contiene {string}', function (mensajeEsperado) {
+  assert.ok(this.errorHttp?.data?.detail, 'No hay detalle de error para validar');
+  assert.ok(this.errorHttp.data.detail.includes(mensajeEsperado));
+});

--- a/features/usuarios_errores.feature
+++ b/features/usuarios_errores.feature
@@ -1,0 +1,21 @@
+# language: es
+Característica: Flujos negativos y reglas de negocio
+  Para validar errores controlados
+  Como equipo de calidad
+  Quiero comprobar respuestas cuando el usuario no existe
+
+  Antecedentes:
+    Dado que no existe un usuario con id 99999
+
+  Escenario: Agregar certificación a usuario inexistente
+    Cuando intento agregar la certificación "Docker" al usuario con id 99999
+    Entonces el servicio responde con código 404
+    Y el error contiene "Usuario no encontrado"
+
+  Escenario: Actualizar usuario inexistente con datos en tabla
+    Cuando intento actualizar el usuario con id 99999 con los datos
+      | campo  | valor               |
+      | nombre | Usuario Fantasma    |
+      | correo | fantasma@example.io |
+    Entonces el servicio responde con código 404
+    Y el error contiene "Usuario no encontrado"

--- a/features/usuarios_outline.feature
+++ b/features/usuarios_outline.feature
@@ -1,0 +1,16 @@
+# language: es
+Característica: Validación con Esquema del escenario
+  Para cubrir variaciones de entradas
+  Como analista funcional
+  Quiero ejecutar el mismo flujo con diferentes ejemplos
+
+  Esquema del escenario: Crear y modificar un usuario con múltiples ejemplos
+    Cuando creo un usuario con nombre "<nombre_inicial>" y correo "<correo_inicial>"
+    Y actualizo el usuario a nombre "<nombre_final>"
+    Entonces el resultado es exitoso
+    Y el usuario modificado tiene nombre "<nombre_final>"
+
+    Ejemplos:
+      | nombre_inicial | correo_inicial        | nombre_final |
+      | Carla          | carla@example.com     | Carla Pérez  |
+      | Bruno          | bruno+qa@example.com  | Bruno Díaz   |

--- a/features/usuarios_tablas.feature
+++ b/features/usuarios_tablas.feature
@@ -1,0 +1,33 @@
+# language: es
+Característica: Gestión de usuarios con tablas de datos
+  Para modelar flujos de negocio más ricos
+  Como equipo de QA
+  Quiero usar tablas y antecedentes para preparar datos de prueba
+
+  Antecedentes:
+    Dado que existen los siguientes usuarios base
+      | nombre | correo              |
+      | Marta  | marta@example.com   |
+      | Pedro  | pedro@example.com   |
+
+  Escenario: Crear múltiples usuarios en lote con Data Table
+    Cuando creo los siguientes usuarios
+      | nombre | correo            |
+      | Julia  | julia@example.com |
+      | Iván   | ivan@example.com  |
+    Entonces todos los resultados son exitosos
+    Y los usuarios creados incluyen
+      | nombre |
+      | Julia  |
+      | Iván   |
+
+  Escenario: Actualizar correo de un usuario con tabla clave-valor
+    Dado que selecciono al usuario "Marta"
+    Cuando actualizo el usuario seleccionado con los datos
+      | campo  | valor                 |
+      | correo | marta.nuevo@email.com |
+    Entonces el resultado es exitoso
+    Y el usuario seleccionado tiene los datos
+      | campo  | valor                 |
+      | nombre | Marta                 |
+      | correo | marta.nuevo@email.com |


### PR DESCRIPTION
### Motivation
- Ampliar el conjunto de ejemplos BDD para cubrir tablas de datos, antecedentes, esquemas (`Outline`) y flujos negativos para validar reglas de negocio.
- Mejorar la estabilidad de las pruebas E2E esperando que la API esté disponible antes de ejecutar los escenarios.

### Description
- Se añadieron tres nuevos `*.feature` con distintos patrones: `features/usuarios_tablas.feature`, `features/usuarios_outline.feature` y `features/usuarios_errores.feature` para mostrar Data Tables, `Background`, `Scenario Outline` y validación de errores HTTP.
- Se creó `features/steps/usuarios_avanzados.steps.js` con glue code que soporta creación en lote desde tablas, conversión de tablas `campo/valor`, selección/actualización por nombre y manejo de errores HTTP esperados (captura de `error.response`).
- Se actualizó `features/steps/usuarios.steps.js` para arrancar `uvicorn` de forma robusta y esperar la disponibilidad de la API consultando `GET /openapi.json` antes de ejecutar los escenarios.
- Se actualizó `README.md` describiendo los nuevos ejemplos y el comando de ejecución `npm test`.

### Testing
- Ejecuté las pruebas automatizadas con `npm test`, corrigiendo inicialmente fallos por `ECONNREFUSED` añadiendo la espera activa; la ejecución final mostró `9 scenarios (9 passed)` y `36 steps (36 passed)`.
- Todas las pruebas automatizadas relevantes del proyecto pasaron en la ejecución final después de las modificaciones.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d589ee7ae483228d201f3e8df735ef)